### PR TITLE
修复BUG：Object of type OperationalError is not JSON serializable

### DIFF
--- a/website.py
+++ b/website.py
@@ -52,7 +52,7 @@ def keywords(q, source, year, page):
         i += 1
     if len(keywords) - len(operator) != 1:
         print("Error")
-    # base_query = "SELECT * FROM PAPER WHERE ("
+    # base_query = "SELECT * FROM papers WHERE ("
     base_query = "("
     clause = ""
     base_title = "TITLE LIKE'%{0}%'"
@@ -63,7 +63,7 @@ def keywords(q, source, year, page):
             clause += " {0} ".format(operator[i], )
         except IndexError as e:
             print(e)
-            return "SELECT * FROM PAPER WHERE YEAR=1900"
+            return "SELECT * FROM papers WHERE YEAR=1900"
     clause += base_title.format(keywords[-1], )
 
     clause += " OR "
@@ -78,7 +78,7 @@ def keywords(q, source, year, page):
     if year is not None:
         clause += (" AND YEAR IN (" + year + ") ")
 
-    print(clause)
+    # print(clause)
     return base_query + clause
 
 
@@ -94,14 +94,15 @@ def get_info():
     year = request.args.get("y")
     offset = int(request.args.get("offset"))
     limit = int(request.args.get("limit"))
-    conn = sqlite3.connect(sys.path[0] + "/paper.db")
+    conn = sqlite3.connect(sys.path[0] + "/papers.db")
     c = conn.cursor()
     query = keywords(q, source, year, offset)
+    print("query:" + query)
     results = []
 
     # get total count
     try:
-        base_q = "SELECT COUNT(*) FROM PAPER WHERE"
+        base_q = "SELECT COUNT(*) FROM papers WHERE"
         cursor = c.execute(base_q + query)
         total = cursor.fetchone()[0]
     except sqlite3.Error as e:
@@ -109,9 +110,10 @@ def get_info():
 
     # get real data
     try:
-        query = "SELECT * FROM PAPER WHERE" + query
+        query = "SELECT * FROM papers WHERE" + query
         query += " ORDER BY YEAR DESC "
         query += "LIMIT {1} OFFSET {0}".format(offset, limit)
+        print(query)
         cursor = c.execute(query)
         key_list = ["id", "conf", "year", "cat", "title", "href", "abstract", "bib"]
         for item in cursor:
@@ -128,9 +130,9 @@ def get_info():
 
 @app.route('/abstract/<q>')
 def get_abs(q):
-    conn = sqlite3.connect(sys.path[0] + "/paper.db")
+    conn = sqlite3.connect(sys.path[0] + "/papers.db")
     c = conn.cursor()
-    query = "SELECT title,abstract FROM PAPER WHERE id=" + str(int(q))
+    query = "SELECT title,abstract FROM papers WHERE id=" + str(int(q))
     results = []
     try:
         cursor = c.execute(query)

--- a/website.py
+++ b/website.py
@@ -118,9 +118,9 @@ def get_info():
             results.append(dict(zip(key_list, item)))
         msg = {"code": 0, "msg": "success", "rows": results, "total": total}
     except sqlite3.OperationalError as e:
-        msg = {"code": 1, "msg": e, "data": query}
+        msg = {"code": 1, "msg": str(e), "data": query}
     except sqlite3.IntegrityError as e:
-        msg = {"code": 1, "msg": e, "data": query}
+        msg = {"code": 1, "msg": str(e), "data": query}
     finally:
         conn.close()
     return json.dumps(msg)
@@ -138,9 +138,9 @@ def get_abs(q):
             results.append(item)
         msg = {"code": 0, "msg": "success", "data": results}
     except sqlite3.OperationalError as e:
-        msg = {"code": 1, "msg": e, "data": query}
+        msg = {"code": 1, "msg": str(e), "data": query}
     except sqlite3.IntegrityError as e:
-        msg = {"code": 1, "msg": e, "data": query}
+        msg = {"code": 1, "msg": str(e), "data": query}
     finally:
         conn.close()
 


### PR DESCRIPTION
在 Python 3.11、Flask 3.0.x 环境中，前端查询任何关键字会触发 "search" 异常，此时如何直接将异常放入 dict 中会导致后续 json.dumps() 报错。例如：

源代码：
    except sqlite3.IntegrityError as e:
        msg = {"code": 1, "msg": e, "data": query}
修复后的代码：
    except sqlite3.IntegrityError as e:
        msg = {"code": 1, "msg": str(e), "data": query}